### PR TITLE
Fix incorrect variable in Twitter meta tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -41,8 +41,8 @@
   <meta property="og:image" name="twitter:image" content="/assets/img/memoji-bg.png" >
 {% endif %}
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:site" content="@{{ site.twitter }}" />
-  <meta name="twitter:creator" content="@{{ site.twitter }}" />
+  <meta name="twitter:site" content="@{{ site.twitter_username }}" />
+  <meta name="twitter:creator" content="@{{ site.twitter_username }}" />
 
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicon_io/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon_io/favicon-32x32.png">


### PR DESCRIPTION
## Summary
- ensure Twitter meta tags use `twitter_username` from site config

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f81290b2883278f51345cbfb18b70