### PR TITLE
Add workflow to build Jekyll site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+      - name: Build site
+        run: bundle exec jekyll build
+


### PR DESCRIPTION
## Summary
- add `build.yml` workflow that installs Ruby dependencies and builds the Jekyll site

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f836283f48327a788b918ad5177da