### PR TITLE
Fix typo in README principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Writing a few words about my general approach. These are not set in stone, but s
 * **Keep it simple:** When possible, bias toward repeatability, scalability, and avoiding custom/proprietary tooling. As a statically-generated site, the _technology_ should be replaceable in the future with minimal impact.
 * **Focus on content:** As a personal site, the text and images are paramount. Keeping content managed in a clear, easy-to-understand manner is really helpful for others to learn from, but also for my future self :)
 * **Speed is usability:** Even with modern devices, bandwidth and processing impact the experience. This might be more critical to developing/pushing updates; but would be evident if serving original, high-resolution photos (rather than those which are optimized for this layout).
-* **Build scaleable workflows:** Images are currently sized at 1280px (which is 640px @ 2x for high-res "retina" devices); but are typically sourced from much larger source files. When possible, ensure a scalable workflow to generate and replace those images in the future.
+* **Build scalable workflows:** Images are currently sized at 1280px (which is 640px @ 2x for high-res "retina" devices); but are typically sourced from much larger source files. When possible, ensure a scalable workflow to generate and replace those images in the future.
 * **Work in public:** Personal websites have changed a lot over the years; share how this is built, offer guidance and support, and help others to participate in the web.
 
 ### History


### PR DESCRIPTION
## Summary
- correct "scaleable" to "scalable" in the principles section of README

## Testing
- `grep -n scaleable README.md`

------
https://chatgpt.com/codex/tasks/task_e_685860003eb8832793cfab0a9759b532