### PR TITLE
Remove duplicate canonical tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,6 @@
 
   <link rel="stylesheet" href="{{ "/assets/style.css" | relative_url }}"> 
 
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS feed" href="{{ "/feed.xml" | relative_url }}">
 
   <link rel="me" href="https://mastodon.social/@benjaminchait" />


### PR DESCRIPTION
## Summary
- drop extra canonical tag from head.html

## Testing
- `bundle exec jekyll build -q` *(fails: rbenv: version `3.1.4` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858600a187483278d20eb11efaed22c