### PR TITLE
Convert 404 page to Markdown

### DIFF
--- a/404.md
+++ b/404.md
@@ -4,8 +4,8 @@ title: 404
 ---
 <script>plausible("404",{ props: { path: document.location.pathname } });</script>
 
-<h1>404</h1>
+# 404
 
-<p><strong>Not found 🙁</strong></p>
+**Not found 🙁**
 
-<p><a href="/">Return home</a></p>
+[Return home](/)


### PR DESCRIPTION
## Summary
- Convert 404 page from HTML to Markdown
- Preserve tracking script and front matter

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689ab20808188327a9608a8bb5644252