### PR TITLE
chore: output archives in markdown

### DIFF
--- a/archives.md
+++ b/archives.md
@@ -4,10 +4,6 @@ title: Archives
 permalink: /archives
 published: true
 ---
-<ul class="posts">
-  {% for post in site.posts %}
-    <li>
-      <a href="{% if post.external %}{{ post.external }}{% else %}{{ post.url }}{% endif %}"><span class="title">{{ post.title }}</span></a> <span class="date">{{ post.date | date: "%-d %B %Y" }}</span>
-    </li>
-  {% endfor %}
-</ul>
+{% for post in site.posts %}
+- [{{ post.title }}]({{ post.url }}) {{ post.date | date: "%-d %B %Y" }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- list archive posts using markdown bullet links

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689ab219378c8327873f4084901bd14f