### PR TITLE
Use Markdown for image and paragraph markup

### DIFF
--- a/about.md
+++ b/about.md
@@ -4,11 +4,10 @@ title: About
 permalink: /about
 ogimage: /assets/img/about/IMG_2713.jpeg
 ---
-<div style="width: 100%;"><center>
-  <img src="/assets/img/about/IMG_2713.jpeg" alt="Benjamin and Lyra, photo 1 of 3" style="width: 32%; max-width: 200px;" />
-  <img src="/assets/img/about/IMG_2715.jpeg" alt="Benjamin and Lyra, photo 2 of 3" style="width: 32%; max-width: 200px;" />
-  <img src="/assets/img/about/IMG_2716.jpeg" alt="Benjamin and Lyra, photo 3 of 3" style="width: 32%; max-width: 200px;" />
-</center></div>
+![Benjamin and Lyra, photo 1 of 3](/assets/img/about/IMG_2713.jpeg){:style="width: 32%; max-width: 200px;"}
+![Benjamin and Lyra, photo 2 of 3](/assets/img/about/IMG_2715.jpeg){:style="width: 32%; max-width: 200px;"}
+![Benjamin and Lyra, photo 3 of 3](/assets/img/about/IMG_2716.jpeg){:style="width: 32%; max-width: 200px;"}
+{:style="width: 100%; text-align: center;"}
 
 👋 Hi hello, I’m Benjamin (he/him).<br />
 

--- a/about/favorites/boulder.md
+++ b/about/favorites/boulder.md
@@ -4,7 +4,7 @@ title: Boulder favorites
 permalink: /about/favorites/boulder
 ogimage: /assets/img/about/favorites/boulder/IMG_0253.jpeg
 ---
-<img src="/assets/img/about/favorites/boulder/IMG_0253.jpeg" alt="Boulder" />
+![Boulder](/assets/img/about/favorites/boulder/IMG_0253.jpeg)
 
 _Last updated 23 June 2025._
 

--- a/about/favorites/chicago.md
+++ b/about/favorites/chicago.md
@@ -4,11 +4,10 @@ title: Chicago favorites
 permalink: /about/favorites/chicago
 ogimage: /assets/img/about/favorites/chicago/2E8A1C3B-2880-48A4-BDBF-A7F7585E06D1.jpeg
 ---
-<div style="width: 100%;"><center>
-  <img src="/assets/img/about/favorites/chicago/2E8A1C3B-2880-48A4-BDBF-A7F7585E06D1.jpeg" alt="Chicago sunrise approach, photo 1 of 3" style="width: 32%; max-width: 200px;" />
-  <img src="/assets/img/about/favorites/chicago/A1BBA7DC-F575-4A43-BC43-F8E5479B7A77.jpeg" alt="Chicago sunrise approach, photo 2 of 3" style="width: 32%; max-width: 200px;" />
-  <img src="/assets/img/about/favorites/chicago/D620F557-C41B-4EA5-BD86-7C3C52476BA6.jpeg" alt="Chicago sunrise approach, photo 3 of 3" style="width: 32%; max-width: 200px;" />
-</center></div>
+![Chicago sunrise approach, photo 1 of 3](/assets/img/about/favorites/chicago/2E8A1C3B-2880-48A4-BDBF-A7F7585E06D1.jpeg){:style="width: 32%; max-width: 200px;"}
+![Chicago sunrise approach, photo 2 of 3](/assets/img/about/favorites/chicago/A1BBA7DC-F575-4A43-BC43-F8E5479B7A77.jpeg){:style="width: 32%; max-width: 200px;"}
+![Chicago sunrise approach, photo 3 of 3](/assets/img/about/favorites/chicago/D620F557-C41B-4EA5-BD86-7C3C52476BA6.jpeg){:style="width: 32%; max-width: 200px;"}
+{:style="width: 100%; text-align: center;"}
 
 _Last updated 22 June 2025._
 

--- a/about/favorites/portland.md
+++ b/about/favorites/portland.md
@@ -4,7 +4,7 @@ title: Portland favorites
 permalink: /about/favorites/portland
 ogimage: /assets/img/about/favorites/portland/IMG_0074.jpeg
 ---
-<img src="/assets/img/about/favorites/portland/IMG_0074.jpeg" alt="Multnomah Falls" />
+![Multnomah Falls](/assets/img/about/favorites/portland/IMG_0074.jpeg)
 
 _Last updated 26 August 2024._
 

--- a/about/favorites/san-francisco.md
+++ b/about/favorites/san-francisco.md
@@ -4,7 +4,7 @@ title: San Francisco favorites
 permalink: /about/favorites/san-francisco
 ogimage: /assets/img/about/favorites/san-francisco/IMG_2705.jpeg
 ---
-<img src="/assets/img/about/favorites/san-francisco/IMG_2705.jpeg" alt="San Francisco sunset" />
+![San Francisco sunset](/assets/img/about/favorites/san-francisco/IMG_2705.jpeg)
 
 _Last updated 1 June 2025._
 

--- a/about/favorites/washington-dc.md
+++ b/about/favorites/washington-dc.md
@@ -4,7 +4,7 @@ title: Washington DC favorites
 permalink: /about/favorites/washington-dc
 ogimage: /assets/img/about/favorites/washington-dc/IMG_9037.jpeg
 ---
-<img src="/assets/img/about/favorites/washington-dc/IMG_9037.jpeg" alt="Tidal Basin" />
+![Tidal Basin](/assets/img/about/favorites/washington-dc/IMG_9037.jpeg)
 
 _Last updated 2 June 2024._
 

--- a/about/favorites/yosemite.md
+++ b/about/favorites/yosemite.md
@@ -4,7 +4,7 @@ title: Yosemite favorites
 permalink: /about/favorites/yosemite
 ogimage: /assets/img/posts/2020-12-31-seven-years-west/IMG_6223.jpeg
 ---
-<img src="/assets/img/posts/2020-12-31-seven-years-west/IMG_6223.jpeg" alt="Yosemite Valley from Inspiration Point" />
+![Yosemite Valley from Inspiration Point](/assets/img/posts/2020-12-31-seven-years-west/IMG_6223.jpeg)
 
 _Last updated 18 May 2025._
 

--- a/about/luna.md
+++ b/about/luna.md
@@ -7,7 +7,7 @@ published: true
 ---
 # 🐾 I’m a pup named Luna
 
-<img src="/assets/img/posts/2025-06-29-meet-luna/IMG_1267.jpeg" alt="Luna" />
+![Luna](/assets/img/posts/2025-06-29-meet-luna/IMG_1267.jpeg)
 
 photos (and treats!) provided by [Benjamin](/about)
 

--- a/about/lyra.md
+++ b/about/lyra.md
@@ -5,10 +5,14 @@ permalink: /about/lyra
 ogimage: /assets/img/about/lyra/2590D3D5-41B0-40B5-A31F-B80C1CC913D9.jpeg
 published: false
 ---
-<center>
-<h1>🐶 woof, I’m a dog named Lyra</h1>
-<p><a href="https://instagram.com/lyraberner">Instagram</a></p>
-<img src="/assets/img/about/lyra/2590D3D5-41B0-40B5-A31F-B80C1CC913D9.jpeg" alt="Lyra looking to the right" style="max-width:300px;" />
-<img src="/assets/img/about/lyra/IMG_6250.jpeg" alt="Lyra looking straight at the camera" style="max-width:300px;" />
-<p>photos (and treats!) provided by <a href="/about">Benjamin</a></p>
-</center>
+# 🐶 woof, I’m a dog named Lyra
+{:style="text-align:center;"}
+
+[Instagram](https://instagram.com/lyraberner)
+{:style="text-align:center;"}
+
+![Lyra looking to the right](/assets/img/about/lyra/2590D3D5-41B0-40B5-A31F-B80C1CC913D9.jpeg){:style="max-width:300px; display:block; margin:0 auto;"}
+![Lyra looking straight at the camera](/assets/img/about/lyra/IMG_6250.jpeg){:style="max-width:300px; display:block; margin:0 auto;"}
+
+photos (and treats!) provided by [Benjamin](/about)
+{:style="text-align:center;"}

--- a/index.md
+++ b/index.md
@@ -2,11 +2,11 @@
 layout: home
 title: Benjamin Chait
 ---
-<img src="/assets/img/IMG_0534.jpeg" alt="Benjamin memoji" style="float: left; width: 9rem; border-radius: 50%; margin: 0 1em 1em 0;" />
+![Benjamin memoji](/assets/img/IMG_0534.jpeg){:style="float: left; width: 9rem; border-radius: 50%; margin: 0 1em 1em 0;"}
 
-<p>Hey there, I’m <a href="/about">Benjamin</a>. I build and scale tech organizations, and empower teams to deliver meaningful outcomes.</p>
+Hey there, I’m [Benjamin](/about). I build and scale tech organizations, and empower teams to deliver meaningful outcomes.
 
-<p>I’ve built products loved by millions, developed and operated financial and identity solutions at scale, and led innovative teams to deliver new capabilities. I’m broadly interested in how we use technology to improve everyday lives; and care deeply about the intersection of privacy, security, and trust.</p>
+I’ve built products loved by millions, developed and operated financial and identity solutions at scale, and led innovative teams to deliver new capabilities. I’m broadly interested in how we use technology to improve everyday lives; and care deeply about the intersection of privacy, security, and trust.
 
 <!-- indie auth https://indieweb.org/rel-me and https://indielogin.com/setup -->
 <link href="https://twitter.com/benjaminchait" rel="me">


### PR DESCRIPTION
## Summary
- replace HTML image tags with Markdown across home and about pages
- convert remaining paragraph tags to plain Markdown

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689d5cdbe9048327a65d649adf4d4844