### PR TITLE
Refactor head metadata and site configuration

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -4,5 +4,6 @@
   "description": "Benjamin's site",
   "url": "https://benjaminchait.net",
   "twitter_username": "benjaminchait",
-  "github_username": "benjaminchait"
+  "github_username": "benjaminchait",
+  "mastodon_url": "https://mastodon.social/@benjaminchait"
 }

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -1,24 +1,19 @@
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width"> <!-- content can also have ", initial-scale=1.0" -->
+  <meta name="viewport" content="width=device-width">
 
-  <title>{% if title != "Benjamin Chait" %}{{ title }} - {% endif %}Benjamin Chait</title>
+  <title>{% if title %}{{ title }} - {% endif %}Benjamin Chait</title>
 
   <link rel="stylesheet" href="/assets/style.css">
 
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS feed" href="/feed.xml">
 
-  <link rel="me" href="https://mastodon.social/@benjaminchait" />
+  <link rel="me" href="{{ site.mastodon_url }}" />
 
   <meta property="og:site_name" content="{{ site.title }}" >
   <meta property="og:locale" content="en_US">
-{% if title %}
-  <meta property="og:title" content="{{ title }}">
-  <meta property="og:type" content="article">
-{% else %}
-  <meta property="og:title" content="{{ site.title }}" >
-  <meta property="og:type" content="website">
-{% endif %}
+  <meta property="og:title" content="{{ title if title else site.title }}">
+  <meta property="og:type" content="{{ og_type if og_type else "website" }}">
 {% if page.url %}
   <meta property="og:url" content="{{ site.url }}{{ page.url | stripTrailingSlash }}" >
   <link rel="canonical" href="{{ site.url }}{{ page.url | stripTrailingSlash }}">
@@ -33,14 +28,12 @@
   <meta name="description" content="{{ site.description }}" >
   <meta property="og:description" content="{{ site.description }}" >
 {% endif %}
-{% if ogimage %}
-  <meta property="og:image" name="twitter:image" content="{{ ogimage }}" >
-{% else %}
-  <meta property="og:image" name="twitter:image" content="/assets/img/memoji-bg.png" >
-{% endif %}
+{% set _ogimage = site.url + (ogimage if ogimage else "/assets/img/memoji-bg.png") %}
+  <meta property="og:image" content="{{ _ogimage }}" >
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@{{ site.twitter_username }}" />
   <meta name="twitter:creator" content="@{{ site.twitter_username }}" />
+  <meta name="twitter:image" content="{{ _ogimage }}" />
 
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicon_io/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon_io/favicon-32x32.png">

--- a/_posts/_posts.json
+++ b/_posts/_posts.json
@@ -1,4 +1,5 @@
 {
   "layout": "post.njk",
-  "tags": "posts"
+  "tags": "posts",
+  "og_type": "article"
 }

--- a/index.md
+++ b/index.md
@@ -1,6 +1,5 @@
 ---
 layout: home.njk
-title: Benjamin Chait
 ---
 ![Benjamin memoji](/assets/img/IMG_0534.jpeg){:style="float: left; width: 9rem; border-radius: 50%; margin: 0 1em 1em 0;"}
 


### PR DESCRIPTION
## Summary
This PR refactors the site's metadata handling in the head template and consolidates configuration, improving maintainability and reducing duplication.

## Key Changes
- **Simplified viewport meta tag**: Removed unnecessary comment about `initial-scale=1.0`
- **Improved title logic**: Changed title condition from `!= "Benjamin Chait"` to simpler truthy check
- **Externalized Mastodon URL**: Moved hardcoded Mastodon URL to `site.json` configuration for easier maintenance
- **Refactored Open Graph tags**: Consolidated conditional og:title and og:type logic using ternary operators instead of if/else blocks
- **Fixed og:image handling**: 
  - Properly constructs full image URLs with `site.url` prefix
  - Consolidated duplicate og:image and twitter:image meta tags into a single variable
  - Added missing `twitter:image` meta tag
- **Added post-level og:type**: Set `og_type: "article"` as default for all posts via `_posts.json`
- **Removed homepage title**: Removed explicit "Benjamin Chait" title from index.md to use site default

## Implementation Details
- Uses Nunjucks template filters and ternary operators for cleaner conditional logic
- Centralizes social media URLs in site configuration for DRY principle
- Ensures all og:image and twitter:image references use consistent, absolute URLs

https://claude.ai/code/session_01B5NHsg5tXa2NcUusPRg5Co