### PR TITLE
Update robots.txt and 404 page sitemap configuration

### DIFF
--- a/404.md
+++ b/404.md
@@ -2,6 +2,7 @@
 layout: default.njk
 title: 404
 permalink: /404.html
+sitemap: false
 ---
 <script>plausible("404",{ props: { path: document.location.pathname } });</script>
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 User-Agent: *
-Disallow: 
+Disallow: /about/imessage-contact-key-verification.txt
 
 User-agent: AdsBot-Google
 User-agent: Amazonbot


### PR DESCRIPTION
## Summary

This PR makes two small but important updates to site configuration:
1. Blocks a specific file from search engine crawling via `robots.txt`
2. Excludes the 404 page from the sitemap

## Changes

- **robots.txt**: Changed `Disallow:` (empty, allowing all) to `Disallow: /about/imessage-contact-key-verification.txt` to prevent search engines from crawling the iMessage contact key verification file
- **404.md**: Added `sitemap: false` to front matter to exclude the 404 error page from the XML sitemap

## Details

These changes improve SEO hygiene by:
- Preventing unnecessary crawling of a domain verification file
- Keeping error pages out of the sitemap (standard practice to avoid confusing search engines with non-canonical content)

Both changes are non-breaking and follow common web standards for site configuration.

https://claude.ai/code/session_01Ce5pEJ4wdCF9sT5XXACR1k