### PR TITLE
Fix duplicate image reference in Lake Aloha post

### DIFF
--- a/_posts/2026-06-21-lake-aloha.md
+++ b/_posts/2026-06-21-lake-aloha.md
@@ -24,7 +24,7 @@ We spent a night in Desolation Wilderness for Luna’s first backpacking trip (a
 ![Lake Aloha sunset][13]
 ![Lake Aloha morning][14]
 ![Luna plays in Lake Aloha][15]
-![Luna stands in Lake Aloha][15]
+![Luna stands in Lake Aloha][16]
 
 [1]: /assets/img/posts/2026-06-21-lake-aloha/IMG_8144.jpeg
 [2]: /assets/img/posts/2026-06-21-lake-aloha/IMG_8163.jpeg


### PR DESCRIPTION
The last image linked reference [15] twice, so IMG_9040.jpeg was never
shown and IMG_9035.jpeg appeared twice. Point the final image at [16].

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QYS4LUUB8J8FTvnNKAgXn2